### PR TITLE
N°4837 Fix RecordComment date format

### DIFF
--- a/datamodel.approval-base.xml
+++ b/datamodel.approval-base.xml
@@ -280,7 +280,7 @@
 					else
 					{
 						// Cumulate into the given (hopefully) text attribute
-						$sDate = date(Dict::S('UI:CaseLog:DateFormat'));
+						$sDate = date(AttributeDateTime::GetFormat());
 						$value .= "\n$sDate - ".$sIssuerInfo." :";
 						$value .= "\n".$sComment;
 					}


### PR DESCRIPTION
Regression introduced in 8eba9ae7 in... iTop 2.3.0 !!
This commit was replacing all the previous dict keys to store date formats by some standard methods using config parameters : 

* AttributeDateTime::GetSQLFormat()
* AttributeDateTime::GetInternalFormat()
* AttributeDateTime::GetFormat()

This appears when using the `comment_attcode` config parameter for the "approval-base" module 

Before the fix you will get : 

> 16473340580:Cam38Europe/Paris020229:Tueam31Europe/ParisMarch2022Tue, 15 Mar 2022 09:47:38 +010003am31 - Rejected by Claude Monet :
sgsg

After the fix : 

> 2022-03-18 18:31:08 - Rejected by Claude Monet : fnxnhfxn

We are using AttributeDateTime::GetFormat() as we are printing a date + time value to the user.